### PR TITLE
Updating source to match the documentation

### DIFF
--- a/payment-service/knative/knative-serving-service.yaml
+++ b/payment-service/knative/knative-serving-service.yaml
@@ -12,4 +12,4 @@ spec:
     spec:
       containers:
         # Replace Project name userXX-cloudnativeapps with project in which payment is deployed
-      - image: YOUR_IMAGE_SERVICE_URL/payment:latest
+      - image: YOUR_IMAGE_SERVICE_URL:latest


### PR DESCRIPTION
The documentation shows `- image: YOUR_IMAGE_SERVICE_URL:latest` and has the user blindly replace YOUR_IMAGE_SERVICE_URL directly with the IMAGE REPOSITORY url.